### PR TITLE
base: fixing error introduced by 20.3.48

### DIFF
--- a/components/base/src/component-base.ts
+++ b/components/base/src/component-base.ts
@@ -269,8 +269,7 @@ import Vue from 'vue';
                  }
                  if (((/[s]\b/).test(tagRef) && innerDirValues) && (!(/[s]\b/).test(tagName) || innerDirValues.length)) {
                     items[tagName] = tempObj;
-                 }
-                 else if (tempObj && Object.keys(tempObj).length !== 0) {
+                 } else (tempObj && Object.keys(tempObj).length !== 0) {
                     items[tagName].push(tempObj);
                  }
               }


### PR DESCRIPTION
Fix #91 
Fixes a bug introduced in commit 08dac8fc4af9c9a92621e37923fc7268f9f35de3

More details here: https://www.syncfusion.com/forums/178147/version-20-3-48-give-typeerror-object-prototype-may-only-be-an-object-or-null-undefined-at?reply=SfrLo5